### PR TITLE
Support Cloudshark's new API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The are a few simple steps to install Cellular Data Network Simulator:
         vim /etc/config/cdns
 
     By default there are 5 profiles: Full, HSDPA, Edge, GPRS and Disabled.
+    
+    In order to support packet capture uploads to Cloudshark, you must edit the cloudshark_api_token parameter. You must create an account at https://www.cloudshark.org and retrieve your API token from the Preferences / API Tokens drop-down menu.
 
 3. Start the service:
 

--- a/etc/config/cdns
+++ b/etc/config/cdns
@@ -5,6 +5,7 @@ config globals 'globals'
 	option max_capture_size '1M'
 	option max_capture_time '60'
 	option default_profile 'full'
+	option cloudshark_api_token 'YOUR_TOKEN_HERE'
 	list interface 'lan'
 	list allowed_subnets '192.168.1.0/24'
 

--- a/etc/init.d/cdns
+++ b/etc/init.d/cdns
@@ -60,6 +60,7 @@ generate_config() {
 	local max_capture_size
 	local max_capture_time
 	local default_profile
+	local cloudshark_api_token
 
 	config_load cdns
 	config_get ifbname globals ifbname "ifb1"
@@ -68,6 +69,7 @@ generate_config() {
 	config_get max_capture_size globals max_capture_size "1M"
 	config_get max_capture_time globals max_capture_time "60"
 	config_get default_profile globals default_profile "full"
+	config_get cloudshark_api_token globals cloudshark_api_token ""
 
 	echo "# General config"
 	echo "STORAGE=$storage"
@@ -75,6 +77,7 @@ generate_config() {
 	echo "MAX_CAPTURE_SIZE=$max_capture_size"
 	echo "MAX_CAPTURE_TIME=$max_capture_time"
 	echo "DEFAULT_PROFILE=$default_profile"
+	echo "CLOUDSHARK_API_TOKEN=$cloudshark_api_token"
 	echo ""
 
 	echo "# Profiles config"

--- a/www/cdns.html
+++ b/www/cdns.html
@@ -173,8 +173,12 @@
 			tr.insertCell(-1).innerHTML = ((today_date != evt.date) ? evt.date + " " : "") + evt.time;
 			tr.insertCell(-1).innerHTML = evt.type;
 			if(evt.type == "CLOUDSHARK") {
-				var link = "http://www.cloudshark.org/captures/" + evt.cloudshark.id;
-				tr.insertCell(-1).innerHTML = "See recorded session: <a target='_blank' href='" + link + "'>" + evt.cloudshark.filename + "</a> (" + formatSizeUnits(evt.cloudshark.data_size, 'B') + ")";
+				if(evt.cloudshark.exceptions != null) {
+					tr.insertCell(-1).innerHTML = "Upload failed. status: " + evt.cloudshark.status + ", exceptions: " + evt.cloudshark.exceptions;
+				} else {
+					var link = "http://www.cloudshark.org/captures/" + evt.cloudshark.id;
+					tr.insertCell(-1).innerHTML = "See recorded session: <a target='_blank' href='" + link + "'>" + evt.cloudshark.filename + "</a>";
+				}
 			} else {
 				tr.insertCell(-1).innerHTML = evt.message;
 			}

--- a/www/cgi-bin/dump
+++ b/www/cgi-bin/dump
@@ -50,6 +50,12 @@ start)
 	EVENT_ID="$(generate_random_number)-$(generate_random_number)-$(generate_random_number)-$(generate_random_number)"
 	DUMP_FILE=$STORAGE/dump-${EVENT_ID}-${PATHS[2]}.pcap
 
+	if [ "$CLOUDSHARK_API_TOKEN" == "" ] || [ "$CLOUDSHARK_API_TOKEN" == "YOUR_TOKEN_HERE" ]
+	then
+		push_event $EVENT_ID FAIL "Please configure a Cloudshark API token in /etc/config/cdns"
+		exit 1
+	fi
+
 	tcpdump -i $OUT_IFNAME -w ${DUMP_FILE}. -W 10 -C $MAX_CAPTURE_SIZE -G $MAX_CAPTURE_TIME host "${PATHS[2]}" &
 	PID=$!
 	echo $PID > $DUMP_PID
@@ -95,7 +101,7 @@ start)
 	for i in 1 2 3
 	do
 		push_event $EVENT_ID UPLOAD "Uploading capture for ${PATHS[2]} to CloudShark ($i try)..."
-		JSON_STATUS=`curl --cacert /usr/lib/cdns/cacert.pem -H "Origin: https://appliance.cloudshark.org" -F "capture[upload]=@${DUMP_FILE}.0" https://www.cloudshark.org/captures.json`
+		JSON_STATUS=`curl --cacert /usr/lib/cdns/cacert.pem --upload-file "${DUMP_FILE}.0" https://www.cloudshark.org/api/v1/${CLOUDSHARK_API_TOKEN}/upload`
 		if [ $? -eq 0 ]
 		then
 			rm -f $DUMP_FILE.*


### PR DESCRIPTION
Cloudshark now requires you to create an account and use an API token
to upload files. See https://support.cloudshark.org/api/upload.html
for more info.

The /etc/config/cdns file must now be edited after installation in
order to provide an API token.

Resolves issue https://github.com/Polidea/Cellular-Data-Network-Simulator/issues/7
